### PR TITLE
[feat]: data structure based on mlc local config from the extracted hf urls

### DIFF
--- a/src/controllers/buildMLCLocalConfig.mjs
+++ b/src/controllers/buildMLCLocalConfig.mjs
@@ -1,0 +1,21 @@
+export function buildMLCLocalConfig(huggingFaceURLs) {
+    const modelList = [];
+    const modelLibMap = {};
+  
+    huggingFaceURLs.forEach(url => {
+      const urlParts = url.split('/');
+      const modelName = urlParts[urlParts.length - 1];
+  
+      modelList.push({
+        model_url: `${process.env.HOST_URL}/${modelName}/params/`,
+        local_id: modelName,
+      });
+  
+      modelLibMap[modelName] = `${process.env.HOST_URL}/${modelName}/${modelName}-webgpu.wasm`;
+    });
+  
+    return {
+      model_list: modelList,
+      model_lib_map: modelLibMap,
+    };
+  }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -5,11 +5,11 @@ import { log } from './utils/logger.mjs';
 import fastify from 'fastify';
 import promiseLimitter from "./utils/concurrency-limit/promise-limitter.mjs"
 import { config as dotenvConfig } from 'dotenv';
+import { buildMLCLocalConfig } from './controllers/buildMLCLocalConfig.mjs';
 
 dotenvConfig();
 const server = fastify();
-console.log(process.env.MODEL_DOWNLOAD_CONCURRENCY)
-const downloadConcurrency = parseInt(process.env.MODEL_DOWNLOAD_CONCURRENCY) || 3;
+const downloadConcurrency = parseInt(process.env.MODEL_DOWNLOAD_CONCURRENCY) || 4;
 const limit = promiseLimitter(downloadConcurrency);
 
 server.get('/', async (request, reply) => {
@@ -47,7 +47,13 @@ server.get('/', async (request, reply) => {
   }
 });
 
-server.listen({ port: 8080 }, (err, address) => {
+server.get('/model-config', async (request, reply) => {
+  const huggingFaceURLs = await fetchPageAndExtractURLs();
+  const config = buildMLCLocalConfig(huggingFaceURLs);
+  reply.send(config);
+});
+
+server.listen({ port: process.env.HOST_PORT || 8000 }, (err, address) => {
   if (err) {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
Added a function that returns a data structure based on mlc local config from the extracted huggingface urls

The mlc local config format -> https://github.com/mlc-ai/web-llm/blob/main/examples/simple-chat/src/mlc-local-config.js

<img width="1019" alt="image" src="https://github.com/llmshare/llmlocalmgr/assets/73993394/7adf2074-67f8-4f0b-9a89-d14f2e72c429">
